### PR TITLE
Implement state-dependent running costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,11 @@ Single test files can be run directly: `julia --project=test -e 'include("test/t
 - Code formatting follows JuliaQuantumControl organization standards
 - Tests require the full test environment with additional dependencies
 - Uses `devrepl.jl` for unified development environment setup
+
+## General Guidelines
+
+* Make sure to only use explicit imports in Julia code, and that there are no imported functions or constants that are not actually used.
+
+* When adding a new dependency to any `Project.toml` file, run `make distclean`, and then `make test/Manifest.toml`, `make docs/Manifest.toml`, etc. to recreate manifest files as necessary.
+
+* Never commit any changes or ask to commit. I will always create git commits manually.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ fallbacks = ExternalFallbacks(
     "propagate_trajectory" => "@extref QuantumControl :jl:function:`QuantumControl.propagate_trajectory`",
     "QuantumControl.Functionals.make_gate_chi" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.make_gate_chi`",
     "QuantumControl.Functionals.make_grad_J_a" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.make_grad_J_a`",
+    "QuantumControl.Functionals.make_xi" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.make_xi`",
     automatic = false,
 )
 
@@ -103,6 +104,7 @@ makedocs(;
     ),
     pages = PAGES,
     warnonly = false,
+    draft = false,
 )
 
 println("Finished makedocs")

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -620,8 +620,8 @@ So far, we have only discussed the evaluation of gradients for final-time functi
   J(\{\epsilon_{nl}\})
   =
   J_T(\{|\Psi_k(T)⟩\}) +
-  \lambda_a \sum_{n=1}^{N_T} \sum_l (g_a)_{nl} +
-  \lambda_b \sum_{n=0}^{N_T} (g_b)_{n}\,,
+  \lambda_a \sum_{n=1}^{N_T} \sum_l (g_a)_{nl}\,dt_n +
+  \lambda_b \sum_k \sum_{n=0}^{N_T} (g_b)_{kn}\,Δt_n \,,
 \end{equation}
 ```
 
@@ -629,12 +629,12 @@ with
 
 ```math
 \begin{equation}
-  (g_a)_{nl} = \frac{1}{dt_n} g_a(\epsilon_{nl}, dt_n)\,,\qquad
-  (g_b)_{n} = \frac{1}{\Delta t_n} g_b(\{|\Psi_k(t_n)⟩\}, t_n)\,.
+  (g_a)_{nl} = g_a(\epsilon_{nl}, dt_n)\,,\qquad
+  (g_b)_{kn} =  g_b(|\Psi_k(t_n)⟩, t_n)\,.
 \end{equation}
 ```
 
-As in Eq. \eqref{eq:psi-time-evolution}, we define ``|\Psi_k(t_n)⟩ = \hat{U}^{(k)}_n \dots \hat{U}^{(k)}_1 |\Psi_k(t=0)⟩``, with the time grid points ``t_0 = 0``, ``t_{N_T} = T``, and with ``\hat{U}^{(k)}_n = \exp[-i \hat{H}_{kn} dt_n]`` as the time evolution operator for the ``n``'th time interval, ``dt_n = t_{n} - t_{n-1}``. Similarly, ``\Delta t_n`` is the time step around the time grid point ``t_n``, e.g. ``\Delta t_0 = dt_1``, ``\Delta t_n = \frac{1}{2}(t_{n+1} - t_{n-1})`` for ``1\le n < N_T``, and ``\Delta t_{N_T} = dt_{N_T}``. For uniform time grids, ``dt_n \equiv \Delta t_n \equiv dt``.
+As in Eq. \eqref{eq:psi-time-evolution}, we define ``|\Psi_k(t_n)⟩ = \hat{U}^{(k)}_n \dots \hat{U}^{(k)}_1 |\Psi_k(t=0)⟩``, with the time grid points ``t_0 = 0``, ``t_{N_T} = T``, and with ``\hat{U}^{(k)}_n = \exp[-i \hat{H}_{kn} dt_n]`` as the time evolution operator for the ``n``'th time interval, ``dt_n = t_{n} - t_{n-1}``. Similarly, ``Δt_n`` is the time step around the time grid point ``t_n``, e.g. ``Δt_0 = dt_1``, ``Δt_n = \frac{1}{2}(t_{n+1} - t_{n-1})`` for ``1\le n < N_T``, and ``Δt_{N_T} = dt_{N_T}``. For uniform time grids, ``dt_n \equiv Δt_n \equiv dt``.
 
 ### Field-dependent running costs
 
@@ -650,7 +650,7 @@ More interesting is the case of state-dependent constraints. Typical examples [
 ```math
 \begin{equation}
   g_{b,\text{trj}}(\{|\Psi_k(t_n)⟩\})
-  = \sum_k \norm{|\Psi_k(t_n)⟩ - |\Psi^{\text{tgt}}_k(t_n)⟩}^2\,,
+  = \norm{|\Psi_k(t_n)⟩ - |\Psi^{\text{tgt}}_k(t_n)⟩}^2\,,
 \end{equation}
 ```
 
@@ -659,7 +659,7 @@ where the time evolution of each state ``|\Psi_k(t_n)⟩`` should be close to so
 ```math
 \begin{equation}
   g_{b,\hat{D}(t)}(\{|\Psi_k(t_n)⟩\})
-  = \sum_k \Braket{\Psi_k(t_n) | \hat{D}(t_n)| \Psi_k(t_n)}\,,
+  = \Braket{\Psi_k(t_n) | \hat{D}(t_n)| \Psi_k(t_n)}\,,
 \end{equation}
 ```
 
@@ -675,17 +675,20 @@ To obtain the full gradient of a functional with a state-dependent running cost,
     2 \Re \sum_k \left[
       \frac{\partial J_T}{\partial |\Psi_k(T)⟩}
       \frac{\partial |\Psi_k(T)⟩}{\partial \epsilon_{nl}}
-      + \sum_{n'=0}^{N_T}
-      \frac{\partial\,(g_b)_{n'}}{\partial |\Psi_k(t_{n'})⟩}
+      + \lambda_b \sum_{n'=0}^{N_T}
+      \frac{\partial\,(g_b)_{kn'}}{\partial |\Psi_k(t_{n'})⟩}
       \frac{\partial |\Psi_k(t_{n'})⟩}{\partial \epsilon_{nl}}
-    \right] \\
-    \label{eq:gradJ-rc2}
-    &=
-    -2 \Re \sum_k \frac{\partial}{\partial \epsilon_{nl}} \left[
-      \bigg\langle \chi_{k}^{(0)}(T) \bigg\vert \hat{U}_{N_T} \dots \hat{U}_1 \bigg\vert \Psi_k(0) \bigg\rangle
-     + \sum_{n'=n}^{N_T}
-        \bigg\langle \xi_{k}(t_{n'}) \bigg\vert \hat{U}_{n'} \dots \hat{U}_1 \bigg\vert \Psi_k(0) \bigg\rangle
+      Δt_{n'}
     \right]
+    \label{eq:gradJ-rc2}\\
+    &=
+    -2 \Re \sum_k \frac{\partial}{\partial \epsilon_{nl}} \Bigg[
+      \bigg\langle \chi_{k}^{(0)}(T) \bigg\vert \hat{U}_{N_T} \dots \hat{U}_1 \bigg\vert \Psi_k(0) \bigg\rangle \notag\\
+    &\qquad\qquad\qquad\qquad\qquad
+     + \lambda_b \sum_{n'=n}^{N_T}
+        \bigg\langle \xi_{k}(t_{n'}) \bigg\vert \hat{U}_{n'} \dots \hat{U}_1 \bigg\vert \Psi_k(0) \bigg\rangle
+        Δt_{n'}
+    \Bigg]
   \end{align}
 ```
 
@@ -696,7 +699,7 @@ with
   \label{eq:chi-boundary-gb1}
   |\chi_k^{(0)}(T)⟩ \equiv - \frac{\partial J_T}{\partial \bra{\Psi_k(T)}}\,,
   \qquad
-  |\xi_k(t_{n'})⟩ \equiv - \frac{\partial\,(g_b)_{n'}}{\partial \bra{\Psi_k(t_{n'})}}\,,
+  |\xi_k(t_{n'})⟩ \equiv - \frac{\partial\,(g_b)_{kn'}}{\partial \bra{\Psi_k(t_{n'})}}\,,
 \end{equation}
 ```
 
@@ -719,11 +722,12 @@ with
 \begin{equation}\label{eq:chi-boundary-gb}
   |\chi_k(T)⟩
   \equiv
-  |\chi_k^{(0)}(T)⟩ + |\xi_k(T)⟩
+  |\chi_k^{(0)}(T)⟩ + \lambda_b |\xi_k(T)⟩ Δt_{N_T}
   =
   - \left(
     \frac{\partial J_T}{\partial \bra{\Psi_k(T)}} +
-    \frac{\partial\,(g_b)_{N_T}}{\partial \bra{\Psi_k(T)}}
+    \lambda_b \frac{\partial\,(g_b)_{kN_T}}{\partial \bra{\Psi_k(T)}}
+    Δt_{N_T}
   \right)
   \,.
 \end{equation}
@@ -748,15 +752,11 @@ with
 \begin{equation}\label{eq:chi-bw-gb}
   |\chi_k(t_n)⟩ =
     \hat{U}_{n+1}^\dagger |\chi_k(t_{n+1})⟩ -
-    \frac{\partial\,(g_b)_{n}}{\partial \bra{\Psi_k(t_n)}}\,.
+    \lambda_b \frac{\partial\,(g_b)_{kn}}{\partial \bra{\Psi_k(t_n)}} Δt_{n}\,.
 \end{equation}
 ```
 
 Thus, there are no fundamental changes to the scheme in [Fig. 1](#fig-grape-scheme) in the presence of state-dependent running costs. The states ``\{|\Psi_k(0)⟩\}`` must be forward-propagated and stored, and then the extended states ``|\tilde\chi_k(t_n)⟩`` are propagated backward to produce the gradient. The only difference is that the boundary state ``|\tilde\chi_k(T)⟩`` is now constructed based on Eq. \eqref{eq:chi-boundary-gb} instead of Eq. \eqref{eq:chi}. Furthermore, the backward propagation uses the discrete inhomogeneous Eq. \eqref{eq:chi-bw-gb}. The inhomogeneity is calculated using the forward-propagated states stored previously, with the derivative of ``g_b`` performed analytically or by automatic differentiation.
-
-!!! warning
-
-    Support for state-dependent running costs is planned for a future version of `GRAPE.jl`; currently, there are no parameters to pass for `g_b`, `lambda_a`, etc.
 
 ## Optimizers
 

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -649,7 +649,7 @@ More interesting is the case of state-dependent constraints. Typical examples [
 
 ```math
 \begin{equation}
-  g_{b,\text{trj}}(\{|\Psi_k(t_n)⟩\})
+  g_{b,\text{trj}}(|\Psi_k(t_n)⟩)
   = \norm{|\Psi_k(t_n)⟩ - |\Psi^{\text{tgt}}_k(t_n)⟩}^2\,,
 \end{equation}
 ```
@@ -658,7 +658,7 @@ where the time evolution of each state ``|\Psi_k(t_n)⟩`` should be close to so
 
 ```math
 \begin{equation}
-  g_{b,\hat{D}(t)}(\{|\Psi_k(t_n)⟩\})
+  g_{b,\hat{D}(t)}(|\Psi_k(t_n)⟩)
   = \Braket{\Psi_k(t_n) | \hat{D}(t_n)| \Psi_k(t_n)}\,,
 \end{equation}
 ```

--- a/src/docstring.jl
+++ b/src/docstring.jl
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 @doc raw"""
-Solve a quantum control problem using the GRAPE method.
+Solve a quantum control problem, using the GRAPE method.
 
 ```julia
 using GRAPE
@@ -15,7 +15,12 @@ result = GRAPE.optimize(trajectories, tlist; J_T, kwargs...)
 minimizes a functional
 
 ```math
-J(\{ϵ_{nl}\}) = J_T(\{|Ψ_k(T)⟩\}) + λ_a J_a(\{ϵ_{nl}\})\,,
+J(\{ϵ_{nl}\}) = J_T(\{|Ψ_k(T)⟩\}) + λ_a J_a(\{ϵ_{nl}\}) + λ_b \underbrace{\sum_k \sum_n g_b(|Ψ_k(t_n)⟩) \, Δt_n}_{%
+    \begin{align*}
+     & = J_b(\{|Ψ_k(t_n)⟩\}) \\
+     & \approx \sum_k \int_{0}^{T} g_b(|Ψ_k(t)⟩)\,dt
+    \end{align*}
+}\,,
 ```
 
 via the GRAPE method, where the final time functional ``J_T`` depends
@@ -48,12 +53,20 @@ The backward-propagation of ``|\chi_k(t)⟩`` has the boundary condition
     |\chi_k(T)⟩ \equiv - \frac{\partial J_T}{\partial ⟨\Psi_k(T)|}\,.
 ```
 
-The final-time gradient ``\nabla J_T`` is combined with the gradient for the
-running costs, and the total gradient is then fed into an optimizer
-(L-BFGS-B by default) that iteratively changes the values ``\{ϵ_{nl}\}`` to
-minimize ``J``.
+When there is a state-dependent running cost ``g_b(Ψ_k(t))``,
+the backward-propagation and boundary condition contain an additional
+inhomogeneous term proportional to
 
-See [Background](@ref GRAPE-Background) for details.
+```math
+|\xi_k(t)⟩ = -\frac{\partial g_b(Ψ_k(t))}{\partial ⟨Ψ_k(t)|}\,,
+```
+
+leading to a combined gradient ``\nabla J_{Tb}`` for the ``J_T`` and ``J_b``
+terms of the functional. The final-time gradient ``\nabla J_T``, respectively
+``\nabla J_{Tb}``, is further combined with the gradient for the running
+cost ``J_a``, and the total gradient is then fed into an optimizer (L-BFGS-B
+by default) that iteratively changes the values ``\{ϵ_{nl}\}`` to minimize
+``J``. See [Background](@ref GRAPE-Background) for details.
 
 Returns a [`GrapeResult`](@ref).
 
@@ -116,6 +129,22 @@ Returns a [`GrapeResult`](@ref).
 * `grad_J_a`: A function to calculate the gradient of `J_a`. If not given, it
   will be automatically determined. See [`make_grad_J_a`](@ref) for the
   required interface.
+* `g_b`: A function `g_b(Ψ, trajectory, tlist, n)` that evaluates a
+  per-trajectory, per-time-point state-dependent running cost, where `Ψ` is
+  the forward-propagated state, `trajectory` is the corresponding trajectory,
+  `tlist` is the time grid, and `n` is the 1-based index into `tlist`. The
+  full state-dependent running cost is defined, based on `g_b`, as
+  ``J_b = \sum_k \sum_n g_b(|Ψ_k(t_n)⟩, t_n) \, Δt_n`` with ``Δt_n`` the
+  [time step around the time grid point ``t_n``](@ref Overview-Running-Costs).
+  If not given, no state-dependent running cost is used.
+* `xi`: A function `xi(Ψ, trajectory, tlist, n)` that evaluates the
+  inhomogeneity in the backward propagation due to a state-dependent running
+  cost. This inhomogeneity is ``λ_b Δt_n |ξ_k(t_n)⟩`` with
+  ``|ξ_k(t_n)⟩ = -∂(g_b)_{kn}/∂⟨Ψ_k(t_n)|``, where `k` is the index of
+  `trajectory` in the overall `problem.trajectories` and ``t_n`` is the time
+  grid point `tlist[n]`. If not given, it will be automatically determined
+  from `g_b` via [`QuantumControl.Functionals.make_xi`](@ref).
+* `lambda_b=1.0`: A weight for the state-dependent running cost `g_b`.
 * `upper_bound`: An upper bound for the value of any optimized control.
   Time-dependent upper bounds can be specified via `pulse_options`.
 * `lower_bound`: A lower bound for the value of any optimized control.

--- a/src/docstring.jl
+++ b/src/docstring.jl
@@ -114,7 +114,7 @@ Returns a [`GrapeResult`](@ref).
 * `taylor_grad_max_order=100`: If given with `gradient_method=:taylor`, the
   maximum number of terms in the Taylor series. If
   `taylor_grad_check_convergence=true` (default), if the Taylor series does not
-  convergence within the given number of terms, throw an an error. With
+  convergence within the given number of terms, throw an error. With
   `taylor_grad_check_convergence=true`, this is the exact order of the Taylor
   series.
 * `taylor_grad_tolerance=1e-16`: If given with `gradient_method=:taylor` and
@@ -122,7 +122,7 @@ Returns a [`GrapeResult`](@ref).
   the term falls below the given tolerance. Ignored if
   `taylor_grad_check_convergence=false`.
 * `taylor_grad_check_convergence=true`: If given as `true` (default), check the
-  convergence after each term in the Taylor series an stop as soon as the norm
+  convergence after each term in the Taylor series and stop as soon as the norm
   of the term drops below the given number. If `false`, stop after exactly
   `taylor_grad_max_order` terms.
 * `lambda_a=1`: A weight for the running cost `J_a`.

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -195,6 +195,13 @@ function update_result!(wrk::GrapeWrk, i::Int64)
         λₐ = get(wrk.kwargs, :lambda_a, 1.0)
         res.J_a /= λₐ
     end
+    res.J_b_prev = res.J_b
+    if !isnothing(get(wrk.kwargs, :g_b, nothing))
+        lambda_b = get(wrk.kwargs, :lambda_b, 1.0)
+        res.J_b = wrk.J_parts[3] / lambda_b
+    else
+        res.J_b = 0.0
+    end
     (i > 0) && (res.iter = i)
     if i >= res.iter_stop
         res.converged = true
@@ -236,7 +243,7 @@ is called via [`QuantumControl.optimize`](@ref) with `print_iters=true`.
 
 The `print_iter_info` keyword argument specifies what information should be
 printed, and defaults to
-`["iter.", "J_T", "|∇J|", "|Δϵ|", "ΔJ", "FG(F)", "secs"]`.
+`["iter.", "J_T", "ǁ∇Jǁ", "ǁΔϵǁ", "ΔJ", "FG(F)", "secs"]`.
 The `store_iter_info` similarly specifies what information should be returned
 from the callback, so that it can be stored in the `records` field of the
 [`GrapeResult`](@ref) object.
@@ -248,11 +255,22 @@ The available fields for `print_iter_info` and `store_iter_info` are:
   optimized pulses
 - `"J_a"`: The value of the pulse-dependent running cost for the optimized
   pulses
+- `"J_b"`: The value of the state-dependent running cost for the optimized
+  states (excluding ``λ_b``)
 - `"λ_a⋅J_a"`: The total contribution of `J_a` to the full functional `J`
+- `"λ_b⋅J_b"`: The total contribution of `J_b` to the full functional `J`
 - `"J"`: The value of the optimization functional for the optimized pulses
 - `"ǁ∇J_Tǁ"`: The ℓ²-norm of the *current* gradient of the final-time
-  functional. Note that this is usually the gradient of the optimize pulse,
-  not the guess pulse.
+  functional, i.e., `norm(wrk.grad_J_Tb)`. This label is only correct when
+  there is no state-dependent running cost `g_b`. Note that this is usually
+  the gradient of the optimized pulse, not the guess pulse.
+- `"ǁ∇(J_T+λ_b·J_b)ǁ"`: Alias for `"ǁ∇J_Tǁ"`, to be used when a
+  state-dependent running cost `g_b` is present. In that case,
+  `wrk.grad_J_Tb` contains the combined gradient of ``J_T + λ_b J_b``, see
+  [Running costs](@ref Overview-Running-Costs) in the [Background
+  documentation](@ref GRAPE-Background). The two labels are interchangeable
+  and give access to the same value; the choice of label only affects how
+  the column is rendered.
 - `"ǁ∇J_aǁ"`: The ℓ²-norm of the the *current* gradient of the pulse-dependent
   running cost. For comparison with `"ǁ∇J_Tǁ"`.
 - `"λ_aǁ∇J_aǁ"`: The ℓ²-norm of the the *current* gradient of the complete
@@ -276,8 +294,12 @@ The available fields for `print_iter_info` and `store_iter_info` are:
   iteration
 - `"ΔJ_a"`:  The change in the control-dependent running cost relative to the
   previous iteration
+- `"ΔJ_b"`:  The change in the state-dependent running cost relative to the
+  previous iteration (excluding ``λ_b``)
 - `"λ_a⋅ΔJ_a"`: The change in the control-dependent running cost term
   relative to the previous iteration.
+- `"λ_b⋅ΔJ_b"`: The change in the state-dependent running cost term relative
+  to the previous iteration.
 - `"ΔJ"`:  The change in the total optimization functional relative to the
   previous iteration.
 - `"FG(F)"`:  The number of functional/gradient evaluation (FG), or pure
@@ -289,16 +311,16 @@ function make_grape_print_iters(; kwargs...)
         "iter.",
         "J_T",
         "J_a",
-        # "J_b",
+        "J_b",
         "λ_a⋅J_a",
-        # "λ_b⋅J_b",
+        "λ_b⋅J_b",
         "J",
         "ǁ∇J_Tǁ",
+        "ǁ∇(J_T+λ_b·J_b)ǁ",
         "ǁ∇J_aǁ",
         "λ_aǁ∇J_aǁ",
-        # "ǁ∇J_bǁ",
         "λ_a⋅ΔJ_a",
-        # "λ_b⋅ΔJ_b",
+        "λ_b⋅ΔJ_b",
         "ǁ∇Jǁ",
         "ǁΔϵǁ",
         "ǁϵǁ",
@@ -311,17 +333,18 @@ function make_grape_print_iters(; kwargs...)
         "α",
         "ΔJ_T",
         "ΔJ_a",
-        # "ΔJ_b",
+        "ΔJ_b",
         "λ_a⋅ΔJ_a",
-        # "λ_b⋅ΔJ_b",
+        "λ_b⋅ΔJ_b",
         "ΔJ",
         "FG(F)",
         "secs"
-    ]  # TODO: update docs when J_b is implemented
+    ]
     delta_headers = Set([
         "ΔJ_T",
         "λ_a⋅ΔJ_a",
         "ΔJ_a",
+        "ΔJ_b",
         "λ_b⋅ΔJ_b",
         "ΔJ",
         "ǁΔϵǁ",
@@ -355,6 +378,26 @@ function make_grape_print_iters(; kwargs...)
     function print_table(wrk, iteration, args...)
 
         λ_a = get(wrk.kwargs, :lambda_a, 1.0)
+        λ_b = get(wrk.kwargs, :lambda_b, 1.0)
+        if iteration == 0
+            has_g_b = !isnothing(get(wrk.kwargs, :g_b, nothing))
+            if has_g_b && ("ǁ∇J_Tǁ" ∈ needed_fields)
+                @warn (
+                    "The label \"ǁ∇J_Tǁ\" was requested, but the optimization " *
+                    "includes a state-dependent running cost `g_b`. The gradient " *
+                    "stored in `wrk.grad_J_Tb` is the combined gradient of " *
+                    "J_T + λ_b·J_b. Consider using the label " *
+                    "\"ǁ∇(J_T+λ_b·J_b)ǁ\" instead."
+                )
+            end
+            if !has_g_b && ("ǁ∇(J_T+λ_b·J_b)ǁ" ∈ needed_fields)
+                @warn (
+                    "The label \"ǁ∇(J_T+λ_b·J_b)ǁ\" was requested, but the " *
+                    "optimization does not include a state-dependent running " *
+                    "cost `g_b`."
+                )
+            end
+        end
         info_vals["iter."] = iteration
         info_vals["J_T"] = wrk.result.J_T
         info_vals["ΔJ_T"] = wrk.result.J_T - wrk.result.J_T_prev
@@ -363,9 +406,16 @@ function make_grape_print_iters(; kwargs...)
         ΔJ_a = wrk.result.J_a - wrk.result.J_a_prev
         info_vals["ΔJ_a"] = ΔJ_a
         info_vals["λ_a⋅ΔJ_a"] = λ_a * ΔJ_a
-        info_vals["J"] = wrk.result.J_T + λ_a * wrk.result.J_a
-        if "ǁ∇J_Tǁ" ∈ needed_fields
-            info_vals["ǁ∇J_Tǁ"] = norm(wrk.grad_J_T)
+        info_vals["J_b"] = wrk.result.J_b
+        info_vals["λ_b⋅J_b"] = wrk.J_parts[3]
+        ΔJ_b = wrk.result.J_b - wrk.result.J_b_prev
+        info_vals["ΔJ_b"] = ΔJ_b
+        info_vals["λ_b⋅ΔJ_b"] = λ_b * ΔJ_b
+        info_vals["J"] = wrk.result.J_T + λ_a * wrk.result.J_a + λ_b * wrk.result.J_b
+        if ("ǁ∇J_Tǁ" ∈ needed_fields) || ("ǁ∇(J_T+λ_b·J_b)ǁ" ∈ needed_fields)
+            nrm_∇J_Tb = norm(wrk.grad_J_Tb)
+            info_vals["ǁ∇J_Tǁ"] = nrm_∇J_Tb
+            info_vals["ǁ∇(J_T+λ_b·J_b)ǁ"] = nrm_∇J_Tb
         end
         if ("ǁ∇J_aǁ" ∈ needed_fields) || ("λ_aǁ∇J_aǁ" ∈ needed_fields)
             nrm_∇J_a = norm(wrk.grad_J_a)
@@ -376,8 +426,9 @@ function make_grape_print_iters(; kwargs...)
             info_vals["ǁ∇Jǁ"] = norm(gradient(wrk; which = :initial))
         end
         if "ΔJ" ∈ needed_fields
-            J = wrk.result.J_T + λ_a * wrk.result.J_a
-            J_prev = wrk.result.J_T_prev + λ_a * wrk.result.J_a_prev
+            J = wrk.result.J_T + λ_a * wrk.result.J_a + λ_b * wrk.result.J_b
+            J_prev =
+                wrk.result.J_T_prev + λ_a * wrk.result.J_a_prev + λ_b * wrk.result.J_b_prev
             info_vals["ΔJ"] = J - J_prev
         end
         if ("ǁΔϵǁ/ǁϵǁ" ∈ needed_fields) ||
@@ -431,6 +482,7 @@ function make_grape_print_iters(; kwargs...)
             "FG(F)" => 8,
             "secs" => 8,
             "∠°" => 7,
+            "ǁ∇(J_T+λ_b·J_b)ǁ" => 17,
         )
 
         if length(print_iter_info) > 0
@@ -640,6 +692,8 @@ function evaluate_functional(pulsevals, wrk; storage = nothing, count_call = tru
     J_T = wrk.kwargs[:J_T]
     J_a = get(wrk.kwargs, :J_a, nothing)
     λₐ = get(wrk.kwargs, :lambda_a, 1.0)
+    g_b_func = get(wrk.kwargs, :g_b, nothing)
+    λ_b = get(wrk.kwargs, :lambda_b, 1.0)
     trajectories = wrk.trajectories
     N = length(trajectories)
     tlist = wrk.tlist
@@ -664,6 +718,10 @@ function evaluate_functional(pulsevals, wrk; storage = nothing, count_call = tru
         (Φₖ !== nothing) && write_to_storage!(Φₖ, 1, Ψ₀(k))
         # The optional storage exists so that `evaluate_functional` can be used
         # as part of `evaluate_gradient!`.
+        local dt = tlist[2] - tlist[1]
+        if !isnothing(g_b_func)
+            wrk.J_b_trajectory[k] = g_b_func(Ψ₀(k), trajectories[k], tlist, 1) * dt
+        end
         for n = 1:N_T  # `n` is the index for the time interval
             local Ψₖ = prop_step!(wrk.fw_propagators[k])
             if haskey(wrk.fw_prop_kwargs[k], :callback)
@@ -672,6 +730,15 @@ function evaluate_functional(pulsevals, wrk; storage = nothing, count_call = tru
                 cb(wrk.fw_propagators[k], observables)
             end
             (Φₖ !== nothing) && write_to_storage!(Φₖ, n + 1, Ψₖ)
+            if !isnothing(g_b_func)
+                local n_tl = n + 1  # index of point in tlist
+                if n_tl < length(tlist)
+                    dt = 0.5 * (tlist[n_tl+1] - tlist[n_tl-1])
+                else
+                    dt = tlist[end] - tlist[end-1]
+                end
+                wrk.J_b_trajectory[k] += g_b_func(Ψₖ, trajectories[k], tlist, n_tl) * dt
+            end
         end
         local Ψₖ = wrk.fw_propagators[k].state
         wrk.result.tau_vals[k] = isnothing(Ψtgt(k)) ? NaN : (Ψtgt(k) ⋅ Ψₖ)
@@ -684,6 +751,9 @@ function evaluate_functional(pulsevals, wrk; storage = nothing, count_call = tru
     end
     if !isnothing(J_a)
         wrk.J_parts[2] = λₐ * J_a(pulsevals, tlist)
+    end
+    if !isnothing(g_b_func)
+        wrk.J_parts[3] = λ_b * sum(wrk.J_b_trajectory)
     end
     return sum(wrk.J_parts)
 end
@@ -728,13 +798,17 @@ information in `wrk`:
   condition for the backward propagation.
 * `wrk.chi_states_norm`: The original norm of the states ``|χ(T)⟩``, as
   calculated by ``-∂J/∂⟨Ψₖ|``
-* `wrk.grad_J_T`: The vector ``∂J_T/∂ϵ_{nl}, i.e., the gradient only for the
-  final-time part of the functional
+* `wrk.grad_J_Tb`: The vector ``∂(J_T + λ_b J_b)/∂ϵ_{nl}`` when a
+  state-dependent running cost `g_b` is given, or the vector
+  ``∂J_T/∂ϵ_{nl}`` when no `g_b` is given. That is, this gradient contains
+  the combined contributions from the final-time functional and (if present)
+  the state-dependent running cost; the two cannot be separated without an
+  additional backward propagation.
 * `wrk.grad_J_a`: The vector ``∂J_a/∂ϵ_{nl}``, i.e., the gradient only for the
   pulse-dependent running cost.
 
-The gradients are `wrk.grad_J_T` and `wrk.grad_J_a` (weighted by ``λ_a``) into
-are combined into the output `G`.
+The gradients `wrk.grad_J_Tb` and `wrk.grad_J_a` (weighted by ``λ_a``) are
+combined into the output `G`.
 
 Returns the value of the functional.
 """
@@ -745,6 +819,9 @@ function evaluate_gradient!(G, pulsevals, wrk)
     tlist = wrk.tlist
     N_T = length(tlist) - 1  # number of time steps
     L = length(wrk.controls)
+
+    xi_func = get(wrk.kwargs, :xi, nothing)
+    λ_b = get(wrk.kwargs, :lambda_b, 1.0)
 
     wrk.result.fg_calls += 1
     wrk.fg_count[1] += 1
@@ -763,6 +840,17 @@ function evaluate_gradient!(G, pulsevals, wrk)
         χ = chi(Ψ, trajectories; tau = wrk.result.tau_vals)
     else
         χ = chi(Ψ, trajectories)
+    end
+    if !isnothing(xi_func)
+        local dt = tlist[end] - tlist[end-1]
+        @threadsif wrk.use_threads for k = 1:N
+            local xi_T = xi_func(Ψ[k], trajectories[k], tlist, length(tlist))
+            if supports_inplace(χ[k])
+                axpy!(λ_b * dt, xi_T, χ[k])
+            else
+                χ[k] = χ[k] + (λ_b * dt) * xi_T
+            end
+        end
     end
     ρ = norm.(χ)
     χ = normalize_chis!(χ, ρ; chi_min_norm)
@@ -794,6 +882,18 @@ function evaluate_gradient!(G, pulsevals, wrk)
                     wrk.tau_grads[k][n, l] = ρ[k] * (χ̃ₖ.grad_states[l] ⋅ Ψₖ)
                 end
                 resetgradvec!(χ̃ₖ)
+                if !isnothing(xi_func) && n > 1
+                    local xi_n = xi_func(Ψₖ, trajectories[k], tlist, n)
+                    local dt = 0.5 * (tlist[n+1] - tlist[n-1])
+                    if supports_inplace(χ̃ₖ.state)
+                        axpy!(λ_b * dt / ρ[k], xi_n, χ̃ₖ.state)
+                    else
+                        χ̃ₖ = GradVector(
+                            χ̃ₖ.state + (λ_b * dt / ρ[k]) * xi_n,
+                            length(wrk.controls)
+                        )
+                    end
+                end
                 set_state!(wrk.bw_grad_propagators[k], χ̃ₖ)
             end
         end
@@ -862,6 +962,20 @@ function evaluate_gradient!(G, pulsevals, wrk)
                         get(wrk.bw_prop_kwargs[k], :observables, _StoreState())
                     cb(wrk.bw_propagators[k], observables)
                 end
+                if !isnothing(xi_func) && n > 1
+                    local chi_k_state = wrk.bw_propagators[k].state
+                    local xi_n = xi_func(Ψₖ, trajectories[k], tlist, n)
+                    local dt = 0.5 * (tlist[n+1] - tlist[n-1])
+                    if supports_inplace(chi_k_state)
+                        axpy!(λ_b * dt / ρ[k], xi_n, chi_k_state)
+                        set_state!(wrk.bw_propagators[k], chi_k_state)
+                    else
+                        set_state!(
+                            wrk.bw_propagators[k],
+                            chi_k_state + (λ_b * dt / ρ[k]) * xi_n
+                        )
+                    end
+                end
             end
         end
 
@@ -871,8 +985,8 @@ function evaluate_gradient!(G, pulsevals, wrk)
 
     end
 
-    _grad_J_T_via_chi!(wrk.grad_J_T, wrk.result.tau_vals, wrk.tau_grads)
-    copyto!(G, wrk.grad_J_T)
+    _grad_J_T_via_chi!(wrk.grad_J_Tb, wrk.result.tau_vals, wrk.tau_grads)
+    copyto!(G, wrk.grad_J_Tb)
     if haskey(wrk.kwargs, :grad_J_a)
         grad_J_a = get(wrk.kwargs, :grad_J_a, nothing)
         if !isnothing(grad_J_a)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -196,8 +196,9 @@ function update_result!(wrk::GrapeWrk, i::Int64)
         res.J_a /= λₐ
     end
     res.J_b_prev = res.J_b
-    if !isnothing(get(wrk.kwargs, :g_b, nothing))
-        lambda_b = get(wrk.kwargs, :lambda_b, 1.0)
+    lambda_b = get(wrk.kwargs, :lambda_b, 1.0)
+    g_b = get(wrk.kwargs, :g_b, nothing)
+    if !(iszero(lambda_b) && isnothing(g_b))
         res.J_b = wrk.J_parts[3] / lambda_b
     else
         res.J_b = 0.0
@@ -380,7 +381,7 @@ function make_grape_print_iters(; kwargs...)
         λ_a = get(wrk.kwargs, :lambda_a, 1.0)
         λ_b = get(wrk.kwargs, :lambda_b, 1.0)
         if iteration == 0
-            has_g_b = !isnothing(get(wrk.kwargs, :g_b, nothing))
+            has_g_b = !(isnothing(get(wrk.kwargs, :g_b, nothing)) || iszero(λ_b))
             if has_g_b && ("ǁ∇J_Tǁ" ∈ needed_fields)
                 @warn (
                     "The label \"ǁ∇J_Tǁ\" was requested, but the optimization " *
@@ -822,6 +823,9 @@ function evaluate_gradient!(G, pulsevals, wrk)
 
     xi_func = get(wrk.kwargs, :xi, nothing)
     λ_b = get(wrk.kwargs, :lambda_b, 1.0)
+    if iszero(λ_b)
+        xi_func = nothing
+    end
 
     wrk.result.fg_calls += 1
     wrk.fg_count[1] += 1

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -924,21 +924,23 @@ function evaluate_gradient!(G, pulsevals, wrk)
                 else
                     Ψₖ = get_from_storage(wrk.fw_storage[k], n)
                 end
+                # pulsevals layout: L blocks of N_T, so the value of the l'th
+                # control at time interval n is `pulsevals[(l-1)*N_T + n]`.
+                local vals_dict = IdDict(
+                    control => pulsevals[(l-1)*N_T+n] for
+                    (l, control) ∈ enumerate(wrk.controls)
+                )
+                if supports_inplace(Hₖₙ⁺)
+                    evaluate!(Hₖₙ⁺, Hₖ⁺, tlist, n; vals_dict)
+                else
+                    Hₖₙ⁺ = evaluate(Hₖ⁺, tlist, n; vals_dict)
+                end
                 for l = 1:L
                     local μₖₗ = wrk.control_derivs[k][l]
                     if isnothing(μₖₗ)
                         wrk.tau_grads[k][n, l] = 0.0
                     else
-                        local ϵₙ⁽ⁱ⁾ = @view pulsevals[((n-1)*L+1):(n*L)]
-                        local vals_dict = IdDict(
-                            control => val for (control, val) ∈ zip(wrk.controls, ϵₙ⁽ⁱ⁾)
-                        )
                         local μₗₖₙ = evaluate(μₖₗ, tlist, n; vals_dict)
-                        if supports_inplace(Hₖₙ⁺)
-                            evaluate!(Hₖₙ⁺, Hₖ⁺, tlist, n; vals_dict)
-                        else
-                            Hₖₙ⁺ = evaluate(Hₖ⁺, tlist, n; vals_dict)
-                        end
                         local χₖ = wrk.bw_propagators[k].state
                         local χ̃ₗₖ = wrk.taylor_grad_states[l, k][1]
                         local ϕ_temp = wrk.taylor_grad_states[l, k][2:5]

--- a/src/result.jl
+++ b/src/result.jl
@@ -19,10 +19,11 @@ The attributes of a `GrapeResult` object include
 * `J_a`: The value of the running cost ``J_a`` in the current iteration
   (excluding ``λ_a``)
 * `J_a_prev`: The value of ``J_a`` in the previous iteration
-* `J_b`: The value of the state-dependent running cost ``J_b`` in the current
-  iteration (excluding ``λ_b``)
+* `J_b`: If `g_b` and `lambda_b ≠ 0` was given, the value of the
+  state-dependent running cost ``J_b`` in the current iteration
+  (excluding ``λ_b``)
 * `J_b_prev`: The value of ``J_b`` in the previous iteration
-* `tlist`: The time grid on which the control are discetized.
+* `tlist`: The time grid on which the control are discretized.
 * `guess_controls`: A vector of the original control fields (each field
   discretized to the points of `tlist`)
 * `optimized_controls`: A vector of the optimized control fields in the current

--- a/src/result.jl
+++ b/src/result.jl
@@ -19,6 +19,9 @@ The attributes of a `GrapeResult` object include
 * `J_a`: The value of the running cost ``J_a`` in the current iteration
   (excluding ``λ_a``)
 * `J_a_prev`: The value of ``J_a`` in the previous iteration
+* `J_b`: The value of the state-dependent running cost ``J_b`` in the current
+  iteration (excluding ``λ_b``)
+* `J_b_prev`: The value of ``J_b`` in the previous iteration
 * `tlist`: The time grid on which the control are discetized.
 * `guess_controls`: A vector of the original control fields (each field
   discretized to the points of `tlist`)
@@ -47,6 +50,8 @@ mutable struct GrapeResult{STST} <: AbstractOptimizationResult
     J_T_prev::Float64  # previous value of J_T
     J_a::Float64  # the current value of the functional J_a (excluding λ_a)
     J_a_prev::Float64  # previous value of J_a
+    J_b::Float64  # the current value of the functional J_b (excluding λ_b)
+    J_b_prev::Float64  # previous value of J_b
     guess_controls::Vector{Vector{Float64}}
     optimized_controls::Vector{Vector{Float64}}
     states::Vector{STST}
@@ -72,6 +77,8 @@ function GrapeResult(trajectories, tlist, kwargs)
     J_T_prev = 0.0
     J_a = 0.0
     J_a_prev = 0.0
+    J_b = 0.0
+    J_b_prev = 0.0
     optimized_controls = [copy(guess) for guess in guess_controls]
     states = [similar(traj.initial_state) for traj in trajectories]
     start_local_time = now()
@@ -92,6 +99,8 @@ function GrapeResult(trajectories, tlist, kwargs)
         J_T_prev,
         J_a,
         J_a_prev,
+        J_b,
+        J_b_prev,
         guess_controls,
         optimized_controls,
         states,
@@ -125,7 +134,13 @@ GRAPE Optimization Result
 
 
 function Base.convert(::Type{GrapeResult}, result::AbstractOptimizationResult)
-    defaults =
-        Dict{Symbol,Any}(:f_calls => 0, :fg_calls => 0, :J_a => 0.0, :J_a_prev => 0.0)
+    defaults = Dict{Symbol,Any}(
+        :f_calls => 0,
+        :fg_calls => 0,
+        :J_a => 0.0,
+        :J_a_prev => 0.0,
+        :J_b => 0.0,
+        :J_b_prev => 0.0
+    )
     return convert(GrapeResult, result, defaults)
 end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -7,6 +7,7 @@ using QuantumControl.QuantumPropagators.Storage: init_storage
 using QuantumControl.QuantumPropagators.Controls: get_controls, discretize_on_midpoints
 using QuantumControl: Trajectory, init_prop_trajectory
 using QuantumControl.Controls: get_control_derivs
+using QuantumControl.Functionals: make_chi, make_xi
 using QuantumGradientGenerators: GradVector, GradGenerator
 import LBFGSB
 
@@ -311,6 +312,11 @@ function GrapeWrk(trajectories, tlist, kwargs)
     g_b_func = get(kwargs, :g_b, nothing)
     if !isnothing(g_b_func) && !haskey(kwargs, :xi)
         kwargs[:xi] = make_xi(g_b_func)
+    end
+    λ_b = get(kwargs, :lambda_b, 1.0)
+    if iszero(λ_b) && !isnothing(g_b_func)
+        @warn "Argument `g_b` was given with `lambda_b = 0.0`. Ignoring"
+        delete!(kwargs, :g_b)
     end
     if isnothing(g_b_func) && haskey(kwargs, :xi)
         @warn "Argument `xi` was given without `g_b`. Ignoring"

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -29,12 +29,21 @@ attributes:
   `pulsevals` such that mutating `pulsevals` is directly reflected in the next
   propagation step.
 * `gradient`: The total gradient for the guess in the current iteration
-* `grad_J_T`: The *current*  gradient for the final-time part of the
-  functional. This is from the last evaluation of the gradient, which may be
-  for the optimized pulse (depending on the internal of the optimizer)
+* `grad_J_Tb`: The *current* gradient contribution from the backward
+  propagation. When no state-dependent running cost `g_b` is present, this is
+  the gradient ``∂J_T/∂ϵ_{nl}`` of the final-time functional only. When `g_b`
+  is given, the state-dependent running cost enters the backward propagation
+  via the modified boundary condition and an inhomogeneity at each time step
+  (see [Running costs](@ref Overview-Running-Costs) in the [Background
+  documentation](@ref GRAPE-Background)), so this field holds the *combined*
+  gradient ``∂(J_T + λ_b J_b)/∂ϵ_{nl}``. The
+  contributions of ``J_T`` and ``λ_b J_b`` cannot be separated without an
+  additional backward propagation. This is from the last evaluation of the
+  gradient, which may be for the optimized pulse (depending on the internals
+  of the optimizer).
 * `grad_J_a`: The *current*  gradient for the running cost part of the
   functional.
-* `J_parts`: The two-component vector ``[J_T, J_a]``
+* `J_parts`: The three-component vector ``[J_T, λ_a J_a, λ_b J_b]``
 * `upper_bounds`: Upper bound for every `pulsevals`; `+Inf` indicates no bound.
 * `lower_bounds`: Lower bound for every `pulsevals`; `-Inf` indicates no bound.
 * `fg_count`: A two-element vector containing the number of evaluations of the
@@ -77,9 +86,10 @@ mutable struct GrapeWrk{O}
     pulsevals_guess::Vector{Float64}
     pulsevals::Vector{Float64}
     gradient::Vector{Float64}
-    grad_J_T::Vector{Float64}
+    grad_J_Tb::Vector{Float64}
     grad_J_a::Vector{Float64}
     J_parts::Vector{Float64}
+    J_b_trajectory::Vector{Float64}  # per-trajectory J_b accumulator
     upper_bounds::Vector{Float64}
     lower_bounds::Vector{Float64}
     fg_count::Vector{Int64}
@@ -183,9 +193,10 @@ function GrapeWrk(trajectories, tlist, kwargs)
         (l, control) in enumerate(controls)
     )
     gradient = zeros(length(pulsevals))
-    grad_J_T = zeros(length(pulsevals))
+    grad_J_Tb = zeros(length(pulsevals))
     grad_J_a = zeros(length(pulsevals))
-    J_parts = zeros(2)
+    J_parts = zeros(3)
+    J_b_trajectory = zeros(N)
     pulsevals_guess = copy(pulsevals)
     upper_bounds = fill(get(kwargs, :upper_bound, Inf), length(pulsevals))
     lower_bounds = fill(get(kwargs, :lower_bound, -Inf), length(pulsevals))
@@ -297,6 +308,14 @@ function GrapeWrk(trajectories, tlist, kwargs)
     chi = kwargs[:chi]
     chi_takes_tau =
         hasmethod(chi, Tuple{typeof(result.states),typeof(trajectories)}, (:tau,))
+    g_b_func = get(kwargs, :g_b, nothing)
+    if !isnothing(g_b_func) && !haskey(kwargs, :xi)
+        kwargs[:xi] = make_xi(g_b_func)
+    end
+    if isnothing(g_b_func) && haskey(kwargs, :xi)
+        @warn "Argument `xi` was given without `g_b`. Ignoring"
+        delete!(kwargs, :xi)
+    end
     GrapeWrk{O}(
         trajectories,
         tlist,
@@ -307,9 +326,10 @@ function GrapeWrk(trajectories, tlist, kwargs)
         pulsevals_guess,
         pulsevals,
         gradient,
-        grad_J_T,
+        grad_J_Tb,
         grad_J_a,
         J_parts,
+        J_b_trajectory,
         upper_bounds,
         lower_bounds,
         fg_count,
@@ -425,7 +445,7 @@ function gradient(wrk; which = :initial)
         return wrk.gradient
     elseif which == :final
         λₐ = get(wrk.kwargs, :lambda_a, 1.0)
-        G = copy(wrk.grad_J_T)
+        G = copy(wrk.grad_J_Tb)
         axpy!(λₐ, wrk.grad_J_a, G)
         return G
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,11 @@ unicodeplots()
         include("test_pulse_running_cost.jl")
     end
 
+    println("\n* State Running Cost (test_state_running_cost.jl)")
+    @time @safetestset "State Running Cost" begin
+        include("test_state_running_cost.jl")
+    end
+
     println("\n* Taylor Gradient (test_taylor_grad.jl):")
     @time @safetestset "Taylor Gradient" begin
         include("test_taylor_grad.jl")

--- a/test/test_state_running_cost.jl
+++ b/test/test_state_running_cost.jl
@@ -274,6 +274,7 @@ end
 
     opt1_dynamics = propagate(ket1, H_opt1, tlist; method = Cheby, storage = true)
     Pmax1 = maximum(abs2.(opt1_dynamics[2, :]))
+    @test Pmax1 > 0.5
 
     QuantumControl.set_default_ad_framework(nothing; quiet = true)
 
@@ -322,11 +323,27 @@ end
 
     @test Pmax2 / Pmax1 < 1e-1
 
+    result3 = optimize(problem2; method = GRAPE, gradient_method = :taylor)
+    @test result3.iter > result1.iter + 10
+    @test result3.converged
+    @test result3.message == "Convergence check returned true"
+    @test result3.J_b > 0.0
+    @test result3.J_b_prev > 0.0
+
+    H_opt3 = substitute(
+        H,
+        IdDict(ϵ => result3.optimized_controls[i] for (i, ϵ) in enumerate(get_controls(H)))
+    );
+    opt3_dynamics = propagate(ket1, H_opt3, tlist; method = Cheby, storage = true)
+    Pmax3 = maximum(abs2.(opt3_dynamics[2, :]))
+    # Optimizations agree within 5% relative error
+    @test (abs(Pmax3 - Pmax2) / Pmax3) < 0.05
+
     function xi_wrong(Ψ, _, _, _)
         return ComplexF64[0, Ψ[2], 0]  # incorrect sign
     end
-    result3 = optimize(problem2; method = GRAPE, xi = xi_wrong)
-    @test contains(result3.message, "ABNORMAL_TERMINATION_IN_LNSRCH")
+    result4 = optimize(problem2; method = GRAPE, xi = xi_wrong)
+    @test contains(result4.message, "ABNORMAL_TERMINATION_IN_LNSRCH")
 
 
 end

--- a/test/test_state_running_cost.jl
+++ b/test/test_state_running_cost.jl
@@ -7,10 +7,10 @@ using QuantumControl.Functionals: J_T_re, make_xi, J_b
 using Test
 using StableRNGs
 using QuantumControlTestUtils.DummyOptimization: dummy_control_problem
-using QuantumControlTestUtils.RandomObjects: random_matrix
 using QuantumPropagators.Interfaces: check_state
 using LinearAlgebra: dot, norm
 using GRAPE
+using Zygote
 using IOCapture
 
 
@@ -236,11 +236,25 @@ end
     using QuantumControl.Functionals: J_T_ss
     using QuantumPropagators: Cheby
 
+    function g_b(Ψ, _, _, _)
+        return abs2(Ψ[2]) # = ⟨2|Ψ⟩⟨Ψ|2⟩
+    end
+
+    # We first optimize without the running cost, so that we can compare the
+    # two results. We'll still pass `g_b`, but set `lambda_b = 0` to
+    # effectively disable this. This (as opposed to just not passing `g_b`) is
+    # something people are likely to do in real life, and gives as an
+    # opportunity to test that code path.
+
+    QuantumControl.set_default_ad_framework(Zygote; quiet = true)
+
     problem1 = ControlProblem(
         [trajectory],
         tlist;
         J_T = J_T_ss,
         iter_stop = 50,
+        g_b,
+        lambda_b = 0.0,
         check_convergence = res -> begin
             (res.J_T <= 1e-2) && "J_T < 10⁻²"
         end,
@@ -248,6 +262,9 @@ end
     );
 
     result1 = optimize(problem1; method = GRAPE)
+
+    @test iszero(result1.J_b)
+    @test iszero(result1.J_b_prev)
 
     using QuantumControl.Controls: substitute, get_controls
     H_opt1 = substitute(
@@ -258,9 +275,7 @@ end
     opt1_dynamics = propagate(ket1, H_opt1, tlist; method = Cheby, storage = true)
     Pmax1 = maximum(abs2.(opt1_dynamics[2, :]))
 
-    function g_b(Ψ, _, _, _)
-        return abs2(Ψ[2]) # = ⟨2|Ψ⟩⟨Ψ|2⟩
-    end
+    QuantumControl.set_default_ad_framework(nothing; quiet = true)
 
     function xi(Ψ, _, _, _)
         return ComplexF64[0, -Ψ[2], 0]
@@ -295,6 +310,8 @@ end
     @test result2.iter > result1.iter + 10
     @test result2.converged
     @test result2.message == "Convergence check returned true"
+    @test result2.J_b > 0.0
+    @test result2.J_b_prev > 0.0
 
     H_opt2 = substitute(
         H,

--- a/test/test_state_running_cost.jl
+++ b/test/test_state_running_cost.jl
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: © 2026 Michael Goerz <mail@michaelgoerz.net>
+#
+# SPDX-License-Identifier: MIT
+
+using QuantumControl
+using QuantumControl.Functionals: J_T_re, make_xi, J_b
+using Test
+using StableRNGs
+using QuantumControlTestUtils.DummyOptimization: dummy_control_problem
+using QuantumControlTestUtils.RandomObjects: random_matrix
+using QuantumPropagators.Interfaces: check_state
+using LinearAlgebra: dot, norm
+using GRAPE
+using IOCapture
+
+
+@testset "state running cost with manual xi" begin
+
+    rng = StableRNG(1244561944)
+    N = 10
+    problem = dummy_control_problem(; N, n_controls = 2, rng)
+    tlist = problem.tlist
+    trajectories = problem.trajectories
+
+    # Build a random Hermitian "penalty" operator D using the initial state
+    # as a template
+    Ψ₀ = trajectories[1].initial_state
+    A = randn(rng, ComplexF64, N, N)
+    D = A * A' / N  # positive semidefinite, so g_b >= 0
+
+    # g_b penalizes the expectation value of D
+    function g_b(Ψ, traj, tlist, n)
+        return real(dot(Ψ, D * Ψ))
+    end
+
+    # Analytic xi: -D * Ψ (Wirtinger derivative: -∂g_b/∂⟨Ψ|)
+    function xi_manual(Ψ, traj, tlist, n)
+        return -D * Ψ
+    end
+
+    function check_J_b(wrk, iter)
+        g_b_func = wrk.kwargs[:g_b]
+        lambda_b = get(wrk.kwargs, :lambda_b, 1.0)
+        J_b_val = J_b(wrk.fw_storage, wrk.trajectories, wrk.tlist; g_b = g_b_func)
+        @test J_b_val ≈ sum(wrk.J_b_trajectory)
+        @test J_b_val * lambda_b ≈ wrk.J_parts[3]
+        return nothing
+    end
+
+    res = optimize(
+        problem;
+        method = GRAPE,
+        J_T = J_T_re,
+        g_b = g_b,
+        xi = xi_manual,
+        lambda_b = 0.5,
+        iter_stop = 5,
+        callback = check_J_b,
+        rethrow_exceptions = true,
+    )
+    @test res.converged
+    @test res.J_T < 1.0  # some optimization happened
+    @test res.J_b >= 0.0  # g_b >= 0 for PSD D, so J_b >= 0
+
+end
+
+
+@testset "state running cost with auto xi (Zygote)" begin
+
+    import Zygote
+
+    N = 10
+    rng = StableRNG(1244561944)
+    problem = dummy_control_problem(; N, n_trajectories = 2, n_controls = 2, rng)
+
+    function positive_semidefinite_matrix(N; rng = rng)
+        A = randn(rng, ComplexF64, N, N)
+        A * A' / N
+    end
+
+    trajectories = [
+        Trajectory(
+            traj.initial_state,
+            traj.generator;
+            target_state = traj.target_state,
+            D = positive_semidefinite_matrix(N; rng)
+        ) for traj in problem.trajectories
+    ]
+    @test norm(trajectories[1].D - trajectories[2].D) > 1e-2
+    for (i, traj) in enumerate(trajectories)
+        problem.trajectories[i] = traj
+    end
+
+    function g_b(Ψ, traj, tlist, n)
+        return real(dot(Ψ, traj.D * Ψ))
+    end
+
+    Ψ = [copy(traj.initial_state) for traj in trajectories]
+    @test J_T_re(Ψ, trajectories) > 0.0
+
+    # Auto-generate xi via Zygote; should match -D * Psi analytically
+    xi_auto = make_xi(g_b; automatic = :Zygote)
+
+    tlist = problem.tlist
+    ξ1 = xi_auto(Ψ[1], trajectories[1], tlist, 1)
+    ξ2 = xi_auto(Ψ[2], trajectories[2], tlist, 1)
+    @test check_state(ξ1)
+    @test check_state(ξ2)
+    @test norm(ξ1 - ξ2) > 1e-2
+
+    λ_b = 1e-3
+
+    captured = IOCapture.capture(passthrough = true) do
+        optimize(
+            problem;
+            method = GRAPE,
+            J_T = J_T_re,
+            g_b = g_b,
+            xi = xi_auto,
+            lambda_b = λ_b,
+            iter_stop = 5,
+            print_iter_info = [
+                "iter.",
+                "J",
+                "J_T",
+                "J_b",
+                "λ_b⋅J_b",
+                "ǁ∇Jǁ",
+                "ǁ∇(J_T+λ_b·J_b)ǁ",
+                "ǁΔϵǁ",
+                "ΔJ"
+            ],
+            store_iter_info = [
+                "J",
+                "J_T",
+                "J_b",
+                "λ_b⋅J_b",
+                "ǁ∇(J_T+λ_b·J_b)ǁ",
+                "ǁ∇J_Tǁ",
+                "ΔJ"
+            ],
+        )
+    end
+    res = captured.value
+    @test contains(
+        captured.output,
+        "Warning: The label \"ǁ∇J_Tǁ\" was requested, but the optimization includes a state-dependent running cost `g_b`."
+    )
+    for (i, (J, J_T, J_b, λ_b_J_b, nrm_grad_Tb, nrm_grad_T, ΔJ)) in enumerate(res.records)
+        (i > 1) && @test ΔJ < 0.0
+        @test J ≈ J_T + λ_b_J_b
+        @test λ_b_J_b ≈ λ_b * J_b
+        # Both labels point to the same value (norm of wrk.grad_J_Tb).
+        @test nrm_grad_Tb == nrm_grad_T
+    end
+    @test res.converged
+    @test res.J_b >= 0.0
+
+    # Using the "ǁ∇(J_T+λ_b·J_b)ǁ" label without g_b should also emit a
+    # warning at iteration 0.
+    captured = IOCapture.capture(passthrough = false) do
+        optimize(
+            problem;
+            method = GRAPE,
+            J_T = J_T_re,
+            iter_stop = 1,
+            print_iter_info = ["iter.", "J_T", "ǁ∇(J_T+λ_b·J_b)ǁ"],
+        )
+    end
+    @test contains(captured.output, "Warning: The label \"ǁ∇(J_T+λ_b·J_b)ǁ\" was requested")
+
+    # Verify xi_auto matches the analytic gradient -D * Psi
+    D = trajectories[1].D
+    xi_analytic = -D * Ψ[1]
+    xi_zygote = xi_auto(Ψ[1], trajectories[1], tlist, 1)
+    @test norm(xi_zygote - xi_analytic) < 1e-14
+
+end
+
+@testset "STIRAP running-cost optimization" begin
+
+    𝕚 = 1im
+    ω₁ = 0.0;
+    ω₂ = 10.0;
+    ω₃ = 5.0;
+    ω_P = 9.5;
+    ω_S = 4.5;
+
+    Δ_P = (ω₂ - ω₁) - ω_P;
+    Δ_S = (ω₂ - ω₃) - ω_S;
+
+    using LinearAlgebra: Diagonal
+    H0 = Array(Diagonal(ComplexF64[0, Δ_P, Δ_P-Δ_S]))
+
+    H1P_re = 0.5 * ComplexF64[
+        0  1  0
+        1  0  0
+        0  0  0
+    ]
+
+    H1P_im = 0.5 * ComplexF64[
+         0  𝕚  0
+        -𝕚  0  0
+         0  0  0
+    ]
+
+    H1S_re = 0.5 * ComplexF64[
+        0  0  0
+        0  0  1
+        0  1  0
+    ]
+
+    H1S_im = 0.5 * ComplexF64[
+        0  0  0
+        0  0  𝕚
+        0 -𝕚  0
+    ]
+
+    using QuantumControl.Shapes: blackman
+
+    H = hamiltonian(
+        H0,
+        (H1P_re, t -> blackman(t, 1.0, 5.0)),
+        (H1P_im, t -> 0.0),
+        (H1S_re, t -> blackman(t, 0.0, 4.0)),
+        (H1S_im, t -> 0.0)
+    );
+
+    tlist = collect(range(0, 5; length = 501));
+
+    ket1 = ComplexF64[1, 0, 0]
+    ket2 = ComplexF64[0, 1, 0]
+    ket3 = ComplexF64[0, 0, 1]
+    trajectory = Trajectory(ket1, H; target_state = ket3)
+
+    using QuantumControl.Functionals: J_T_ss
+    using QuantumPropagators: Cheby
+
+    problem1 = ControlProblem(
+        [trajectory],
+        tlist;
+        J_T = J_T_ss,
+        iter_stop = 50,
+        check_convergence = res -> begin
+            (res.J_T <= 1e-2) && "J_T < 10⁻²"
+        end,
+        prop_method = Cheby,
+    );
+
+    result1 = optimize(problem1; method = GRAPE)
+
+    using QuantumControl.Controls: substitute, get_controls
+    H_opt1 = substitute(
+        H,
+        IdDict(ϵ => result1.optimized_controls[i] for (i, ϵ) in enumerate(get_controls(H)))
+    );
+
+    opt1_dynamics = propagate(ket1, H_opt1, tlist; method = Cheby, storage = true)
+    Pmax1 = maximum(abs2.(opt1_dynamics[2, :]))
+
+    function g_b(Ψ, _, _, _)
+        return abs2(Ψ[2]) # = ⟨2|Ψ⟩⟨Ψ|2⟩
+    end
+
+    function xi(Ψ, _, _, _)
+        return ComplexF64[0, -Ψ[2], 0]
+    end
+
+    problem2 = ControlProblem(
+        [trajectory],
+        tlist;
+        J_T = J_T_ss,
+        iter_stop = 100,
+        check_convergence = res -> begin
+            (res.J_T <= 1e-2) && (res.J_b <= 1e-2)
+        end,
+        prop_method = Cheby,
+        g_b,
+        xi,
+        lambda_b = 4e-1,
+        print_iter_info = [
+            "iter.",
+            "J",
+            "J_T",
+            "J_b",
+            "λ_b⋅J_b",
+            "ǁ∇(J_T+λ_b·J_b)ǁ",
+            "ǁΔϵǁ",
+            "ΔJ",
+        ],
+        store_iter_info = ["J", "J_T", "J_b", "λ_b⋅J_b", "ǁ∇Jǁ"]
+    );
+
+    result2 = optimize(problem2; method = GRAPE)
+    @test result2.iter > result1.iter + 10
+    @test result2.converged
+    @test result2.message == "Convergence check returned true"
+
+    H_opt2 = substitute(
+        H,
+        IdDict(ϵ => result2.optimized_controls[i] for (i, ϵ) in enumerate(get_controls(H)))
+    );
+    opt2_dynamics = propagate(ket1, H_opt2, tlist; method = Cheby, storage = true)
+    Pmax2 = maximum(abs2.(opt2_dynamics[2, :]))
+
+    @test Pmax2 / Pmax1 < 1e-1
+
+    function xi_wrong(Ψ, _, _, _)
+        return ComplexF64[0, Ψ[2], 0]  # incorrect sign
+    end
+    result3 = optimize(problem2; method = GRAPE, xi = xi_wrong)
+    @test contains(result3.message, "ABNORMAL_TERMINATION_IN_LNSRCH")
+
+
+end


### PR DESCRIPTION
This implements state-dependent running costs as previously derived.

The existing derivation was a bit sloppy with properly keeping track of `λ_b` and `dt`. This has been fixed.

The main interface is for a user to pass a function `g_b(Ψ, trajectory, tlist, n)`, and optionally a function `xi` that calculates the derivative of `g_b` w.r.t. to the `Ψ`. That derivative can also be obtained via automatic differentiation; this functionality relies on upstream definitions from `QuantumControl` in https://github.com/JuliaQuantumControl/QuantumControl.jl/pull/103

Closes #53